### PR TITLE
Ticket #22. Hide product archive. Третий комит

### DIFF
--- a/inc/class-import-products-walker.php
+++ b/inc/class-import-products-walker.php
@@ -129,8 +129,11 @@ class WooMS_Product_Import_Walker {
 			if ( empty( $data['rows'] ) ) {
 				$this->walker_finish();
 				
+				do_action( 'wooms_walker_finish' );
+				
 				return true;
 			}
+			
 			$i = 0;
 			foreach ( $data['rows'] as $key => $value ) {
 				do_action( 'wooms_product_import_row', $value, $key, $data );

--- a/inc/class-import-products.php
+++ b/inc/class-import-products.php
@@ -25,10 +25,6 @@ class woomss_tool_products_import {
 	 */
 	public function load_data( $value, $key, $data ) {
 		
-		if ('variant' == $value['meta']['type']){
-			return;
-			
-		}
 		if ( ! empty( $value['archived'] ) ) {
 			return;
 		}


### PR DESCRIPTION
## Что изменилось

1. Файл `class-hide-old-products.php` - добавлен новый метод для удаления родительской рубрики при синхронизации по группе. Срабатывает на хуке `wooms_walker_finish` после остановки синхронизации
2. Файл `class-import-product-categories.php` - добавлена запись в мету термом значения текущей сессии
3. Файл `class-import-products.php` - удалена лишняя проверка
4. Файл `class-import-products-walker.php` - добавлен хук `wooms_walker_finish` при финише синхронизации 

## Как тестировалось

Тестирование проводилось только на простых товарах 

### Тест 1

- Полная очистка данных
- Синхронизация всех товаров, независимо от групп

### Результат теста 1

Если товара нет на складе, то на сайте ему присваивается статус `Нет в наличии`

### Тест 2

- Полная очистка данных
- Синхронизация всех товаров, независимо от групп. См. результат теста 1
- Переключение на синхронизацию по группам

### Результат теста 2

Если товара нет на складе, то на сайте ему присваивается статус `Нет в наличии`
Всем товарам, не входящим в выбранную группу на сайте присваивается статус `Нет в наличии`
Удаляется родительская рубрика на сайте

### Тест 3

- Полная очистка данных
- Синхронизация всех товаров, независимо от групп. См. результат теста 1
- Переключение на синхронизацию по группам См. результат теста 2
- Переключение на синхронизацию по другой группам

### Результат теста 3

Если товара нет на складе, то на сайте ему присваивается статус `Нет в наличии`
Всем товарам, не входящим в выбранную группу на сайте присваивается статус `Нет в наличии`
Удаляется родительская рубрика на сайте

### Тест 4

- Полная очистка данных
- Синхронизация всех товаров, независимо от групп. См. результат теста 1
- Переключение на синхронизацию по группам См. результат теста 2
- Переключение на синхронизацию по другой группам См. результат теста 3
- Переключение на полную синхронизацию товаров независимо от группы

### Результат теста 4

Всем товарам присваивается статус `В наличии`, кроме товаров, которых нет на складе
Родительские рубрики после тестов 2 и 3 не создаются


## Выявленные ошибки и предложения по их решению

- После теста 4 начинается бардак с рубриками. _Предлагается_: при синхронизации по группам удалять все существующие рубрики и каждый раз их создавать по новой
- При синхронизации по группам обнаружено, что синхронизируются товары с комплектами. _Предлагается_: так как при синхронизации по группам фильтруется ссылка и добавляется ссылка на полный ассортимент, то необходимо в ссылку добавить дополнительный фильтр (если это возможно) для отсекания лишних товаров

@uptimizt 